### PR TITLE
fix: use correct model ids for claude 4 and claude 4.5

### DIFF
--- a/packages/backend/src/ai/llm/client/mod.rs
+++ b/packages/backend/src/ai/llm/client/mod.rs
@@ -51,9 +51,9 @@ pub enum Model {
     #[serde(rename = "o3-mini")]
     O3Mini,
 
-    #[serde(rename = "claude-sonnet-4-5-20250929")]
+    #[serde(rename = "claude-4-5-sonnet-latest")]
     Claude45Sonnet,
-    #[serde(rename = "claude-sonnet-4-20250514")]
+    #[serde(rename = "claude-4-sonnet-latest")]
     Claude4Sonnet,
     #[serde(rename = "claude-3-7-sonnet-latest")]
     Claude37Sonnet,

--- a/packages/types/src/ai.types.ts
+++ b/packages/types/src/ai.types.ts
@@ -18,8 +18,8 @@ export enum BuiltInModelIDs {
   O4Mini = 'o4-mini',
   O3Mini = 'o3-mini',
   ClaudeSonnet = 'claude-3-5-sonnet-latest',
-  ClaudeSonnet45 = 'claude-sonnet-4-5-20250929',
-  ClaudeSonnet4 = 'claude-sonnet-4-20250514',
+  ClaudeSonnet45 = 'claude-4-5-sonnet-latest',
+  ClaudeSonnet4 = 'claude-4-sonnet-latest',
   ClaudeSonnet37 = 'claude-3-7-sonnet-latest',
   ClaudeHaiku = 'claude-3-5-haiku-latest',
   Gemini2Flash = 'gemini-2.0-flash'


### PR DESCRIPTION
## Changes
- Uses right model ids for anthropic claude 4.5 and claude 4 models
- Fixes error message operator order in parsing AI error on other errors