### PR TITLE
fix: set navbar to fixed height to avoid gaps with wcvs

### DIFF
--- a/app/src/renderer/Core/components/NavigationBar/NavigationBar.svelte
+++ b/app/src/renderer/Core/components/NavigationBar/NavigationBar.svelte
@@ -153,6 +153,7 @@
   class:grey={[ViewType.Notebook, ViewType.NotebookHome].includes($activeViewType)}
   class:roundLeftCorner
   class:roundRightCorner
+  class="navbar"
 >
   {@render leftChildren?.()}
 
@@ -339,6 +340,10 @@
           margin-left: -1.5px;
         }
       }
+    }
+
+    .navbar {
+      height: 32px;
     }
 
     .breadcrumbs {


### PR DESCRIPTION
<img width="483" height="204" alt="image" src="https://github.com/user-attachments/assets/63b7bcb8-3ce1-40f2-91f7-f8cd02675a26" />

- using a fixed height prevents the UI from having this gap.