### PR TITLE
feat: show prompts within notes again

### DIFF
--- a/app/src/renderer/Resource/components/ChatInput.svelte
+++ b/app/src/renderer/Resource/components/ChatInput.svelte
@@ -66,11 +66,16 @@
 
   let focusInput: () => void
   let chatInputElement: HTMLElement
+  let tempContent: string = ''
 
   // ==== Status Message Management
 
   export const showStatus = (message: AIChatStatusMessage) => {
     statusMessage.set(message)
+
+    if (message.type === 'error') {
+      setContent(tempContent, true)
+    }
   }
 
   export const dismissStatus = () => {
@@ -198,10 +203,14 @@
       log.debug('No editor, not submitting')
       return
     }
+
+    tempContent = currentContent
+
     const mentions: MentionItem[] = editor.getMentions()
     dispatch('submit', { query: currentContent, mentions })
     tick().then(() => {
       focus()
+      clearEditor()
     })
   }
 

--- a/app/src/renderer/Resource/components/TextResource.svelte
+++ b/app/src/renderer/Resource/components/TextResource.svelte
@@ -1310,7 +1310,7 @@
         id: options.generationID,
         textQuery: textQuery,
         autoScroll: options.autoScroll,
-        showPrompt: false, //options.showPrompt,
+        showPrompt: options.showPrompt,
         loadingMessage: loadingMessage
       })
 

--- a/packages/services/src/lib/ai/editor.ts
+++ b/packages/services/src/lib/ai/editor.ts
@@ -134,6 +134,23 @@ export class EditorAIGeneration {
     return null
   }
 
+  deleteNode(id: string, type: string, transaction?: Transaction) {
+    this.log.debug('Deleting AI generation node', id, type)
+
+    const nodePos = this.noteEditor.getNodeByID(id, type)
+    if (!nodePos) {
+      this.log.warn('Node not found, cannot delete', id, type)
+      return
+    }
+
+    const tr = transaction || this.editor.view.state.tr
+    tr.delete(nodePos.pos, nodePos.pos + nodePos.node.nodeSize)
+
+    if (!transaction) {
+      this.editor.view.dispatch(tr)
+    }
+  }
+
   updateStatus(status: AIGenerationStatus) {
     this.log.debug('Updating AI generation node status', this.id, status)
 
@@ -141,6 +158,10 @@ export class EditorAIGeneration {
 
     const tr = this.editor.view.state.tr
     this.updateAIGenerationNodeStatus(status, tr)
+
+    if (status === 'failed') {
+      this.deleteNode(this.id, 'generation', tr)
+    }
 
     this.editor.view.dispatch(tr)
   }


### PR DESCRIPTION
When kicking off a completion from TTY or little TTY at the bottom of a note it now inserts the prompt into the note again.

<img width="1478" height="558" alt="CleanShot 2025-10-22 at 14 05 46@2x" src="https://github.com/user-attachments/assets/0f32a8a3-f8e4-442c-9e53-cfd38f254216" />

It also clears the input field and only inserts the prompt into the input field again if there is an error.