### PR TITLE
chore: Update `--text` for improved contrast

### DIFF
--- a/app/src/renderer/Resource/Resource.svelte
+++ b/app/src/renderer/Resource/Resource.svelte
@@ -218,7 +218,7 @@
 
     -electron-corner-smoothing: 60%;
     //font-size: 11px;
-    --text: light-dark(#586884, #ddd6d0);
+    --text: light-dark(#586884, #c7d2ff);
     --text-p3: color(display-p3 0.3571 0.406 0.5088);
     --text-light: #666666;
     --background-dark: radial-gradient(


### PR DESCRIPTION
This small pull request solves the problem discussed in [this discord thread](https://discord.com/channels/1214223660773154826/1430753227166715914), where **the text in dark mode has very little contrast**.

I **added the light-dark function** and **set the text color for dark mode to `#ddd6d0`** (based on packages/teletype/app.scss .dark) to improve the contrast.

### **before**
<img width="689" height="431" alt="image" src="https://github.com/user-attachments/assets/cb7a3473-4f04-422a-9ed8-65342bb61b80" />

### **after**
<img width="704" height="412" alt="image" src="https://github.com/user-attachments/assets/9c52fed4-4222-46ac-af7b-957726e8aabf" />
