### PR TITLE
chore: fix shortcut for zoom in on page

### DIFF
--- a/packages/services/src/lib/shortcuts/shortcuts.ts
+++ b/packages/services/src/lib/shortcuts/shortcuts.ts
@@ -137,7 +137,7 @@ export const defaultShortcuts: Record<ShortcutActions, ShortcutDefinition<Shortc
   },
   [ShortcutActions.INCREASE_PAGE_ZOOM]: {
     action: ShortcutActions.INCREASE_PAGE_ZOOM,
-    defaultCombo: 'CmdOrCtrl++',
+    defaultCombo: 'CmdOrCtrl+=',
     description: 'Increase tab Zoom',
     priority: ShortcutPriority.Normal
   },


### PR DESCRIPTION
Zoom in (Cmd + =) didn't work before, because the shortcut was assigned to CmdOrCtrl + +, which doesn't actually work because it's a 3 key modifier (+ = Shift + =)

Tested and confirmed I can zoom in on pages now with this change