### PR TITLE
chore (workflows): use github sha cache keys for turbo, fixes wrong turbo cache usage

### DIFF
--- a/.github/workflows/build_on_pr_label.yml
+++ b/.github/workflows/build_on_pr_label.yml
@@ -81,7 +81,7 @@ jobs:
           path: |
             .turbo
             node_modules/.cache/turbo
-          key: ${{ runner.os }}-${{ matrix.architecture }}-turbo-${{ hashFiles('**/package.json', '**/yarn.lock', 'turbo.json') }}
+          key: ${{ runner.os }}-${{ matrix.architecture }}-turbo-${{ github.event.pull_request.head.sha }}
           restore-keys: |
             ${{ runner.os }}-${{ matrix.architecture }}-turbo-
 

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -123,7 +123,7 @@ jobs:
           path: |
             .turbo
             node_modules/.cache/turbo
-          key: ${{ runner.os }}-${{ matrix.architecture }}-turbo-${{ hashFiles('**/package.json', '**/yarn.lock', 'turbo.json') }}
+          key: ${{ runner.os }}-${{ matrix.architecture }}-turbo-${{ github.sha }}
           restore-keys: |
             ${{ runner.os }}-${{ matrix.architecture }}-turbo-
 

--- a/.github/workflows/pull_request_frontend.yml
+++ b/.github/workflows/pull_request_frontend.yml
@@ -45,7 +45,7 @@ jobs:
           path: |
             .turbo
             node_modules/.cache/turbo
-          key: ${{ runner.os }}-${{ matrix.architecture }}-turbo-${{ hashFiles('**/package.json', '**/yarn.lock', 'turbo.json') }}
+          key: ${{ runner.os }}-${{ matrix.architecture }}-turbo-${{ github.event.pull_request.head.sha }}
           restore-keys: |
             ${{ runner.os }}-${{ matrix.architecture }}-turbo-
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -113,7 +113,7 @@ jobs:
           path: |
             .turbo
             node_modules/.cache/turbo
-          key: ${{ runner.os }}-${{ matrix.architecture }}-turbo-${{ hashFiles('**/package.json', '**/yarn.lock', 'turbo.json') }}
+          key: ${{ runner.os }}-${{ matrix.architecture }}-turbo-${{ github.sha }}
           restore-keys: |
             ${{ runner.os }}-${{ matrix.architecture }}-turbo-
 


### PR DESCRIPTION
## Changes

- Uses `github.sha` and `github.event.pull_request.head.sha` for turbo cache keys instead of depdency files hash, this fixes the issue where wrong turbo cache was used in some release workflows