### PR TITLE
fix: fix wrong cases of intent classification

### DIFF
--- a/packages/services/package.json
+++ b/packages/services/package.json
@@ -108,27 +108,29 @@
     "preview": "vite preview",
     "check": "svelte-check --tsconfig ./tsconfig.json",
     "package": "svelte-package",
-    "sync": "svelte-kit sync"
+    "sync": "svelte-kit sync",
+    "test": "vitest run"
   },
   "dependencies": {
-    "fuse.js": "^7.0.0",
     "@deta/editor": "*",
-    "@deta/utils": "*",
     "@deta/teletype": "*",
-    "@deta/web-parser": "*"
+    "@deta/utils": "*",
+    "@deta/web-parser": "*",
+    "fuse.js": "^7.0.0"
   },
   "devDependencies": {
-    "@deta/types": "*",
-    "svelte": "^5.38.1",
-    "@sveltejs/kit": "^2.31.1",
-    "@sveltejs/package": "^2.4.1",
     "@deta/backend": "*",
+    "@deta/types": "*",
     "@horizon/eslint-config": "*",
     "@horizon/typescript-config": "*",
+    "@sveltejs/kit": "^2.31.1",
+    "@sveltejs/package": "^2.4.1",
     "date-fns": "^3.2.0",
     "p-queue": "^8.0.1",
+    "svelte": "^5.38.1",
     "typescript": "^5.5.0",
     "vite": "^7.1.11",
-    "vite-plugin-markdown": "^2.2.0"
+    "vite-plugin-markdown": "^2.2.0",
+    "vitest": "^4.0.6"
   }
 }

--- a/packages/services/src/lib/ai/intentClassifier.test.ts
+++ b/packages/services/src/lib/ai/intentClassifier.test.ts
@@ -1,0 +1,83 @@
+import { describe, it, expect } from 'vitest'
+import { quickGuess, classifyIntent, decideIntent } from './intentClassifier'
+
+describe('Intent Classifier', () => {
+  describe('quickGuess', () => {
+    it('should classify URLs as search', () => {
+      expect(quickGuess('https://github.com')).toBe('search')
+      expect(quickGuess('www.example.com')).toBe('search')
+      expect(quickGuess('github.com')).toBe('search')
+      expect(quickGuess('github.')).toBe('search')
+      expect(quickGuess('github.com/deta/surf')).toBe('search')
+    })
+
+    it('should classify questions with ? as question', () => {
+      expect(quickGuess('what is TypeScript?')).toBe('question')
+      expect(quickGuess('how are you?')).toBe('question')
+    })
+
+    it('should classify question starters as question', () => {
+      expect(quickGuess('how do I learn Python')).toBe('question')
+      expect(quickGuess('what is the weather')).toBe('question')
+      expect(quickGuess('explain quantum computing')).toBe('question')
+    })
+
+    it('should classify short queries as search', () => {
+      expect(quickGuess('weather paris')).toBe('search')
+      expect(quickGuess('best pizza')).toBe('search')
+      expect(quickGuess('life in mars.')).toBe('search')
+      expect(quickGuess('nodejs tutorial')).toBe('search')
+    })
+
+    it('should handle search operators', () => {
+      expect(quickGuess('site:github.com typescript')).toBe('search')
+      expect(quickGuess('filetype:pdf machine learning')).toBe('search')
+    })
+
+    it('should classify longer queries as ambiguous', () => {
+      expect(quickGuess('the quick brown fox jumps over')).toBe('ambiguous')
+    })
+
+    it('should handle edge cases', () => {
+      expect(quickGuess('')).toBe('ambiguous')
+      expect(quickGuess('   ')).toBe('ambiguous')
+    })
+
+    it('should NOT falsely classify sentences ending with period', () => {
+      expect(quickGuess('Please help me.')).toBe('search') // 3 words = search
+      expect(quickGuess('I need assistance with this.')).toBe('ambiguous') // 5 words
+    })
+  })
+
+  describe('classifyIntent', () => {
+    it('should return llm intent for questions', async () => {
+      const result = await classifyIntent('how do I code?')
+      expect(result.intent).toBe('llm')
+      expect(result.confidence).toBeGreaterThan(0.8)
+    })
+
+    it('should return search intent for short queries', async () => {
+      const result = await classifyIntent('weather today')
+      expect(result.intent).toBe('search')
+      expect(result.confidence).toBeGreaterThan(0.8)
+    })
+
+    it('should handle ambiguous cases with question words', async () => {
+      const result = await classifyIntent('please explain the situation to me')
+      expect(result.intent).toBe('llm')
+    })
+  })
+
+  describe('decideIntent', () => {
+    it('should use rules route for high confidence', async () => {
+      const result = await decideIntent('what is this?')
+      expect(result.route).toBe('rules')
+      expect(result.confidence).toBeGreaterThanOrEqual(0.8)
+    })
+
+    it('should use fallback route for lower confidence', async () => {
+      const result = await decideIntent('the weather seems nice today for a walk')
+      expect(result.route).toBe('fallback')
+    })
+  })
+})

--- a/packages/services/src/lib/ai/intentClassifier.ts
+++ b/packages/services/src/lib/ai/intentClassifier.ts
@@ -1,26 +1,41 @@
 import type {
-  IntentType,
   QuickGuessResult,
   ClassificationResult,
   ClassificationResultWithRoute,
   BatchClassificationResult
 } from './intentClassifier.types'
 
+// compiled regexes once at module load time
+const REGEX_PATTERNS = {
+  url: /(https?:\/\/|www\.[a-z0-9-]+\.[a-z]{2,})/i,
+  domain: /(?:^|\s)([a-z0-9-]+\.)+[a-z]{2,}(?:\/|\s|$)/i,
+  searchOperators: /\b(site:|filetype:|intitle:|inurl:|OR|\-)\b/i,
+  questionStarters:
+    /^(how|why|what|who|when|where|which|can|could|should|do|does|did|is|are|am|was|were|explain|tell me|note|create)\b/i,
+  questionWords: /\b(explain|describe|tell me|show me|help|tutorial|guide|learn)\b/,
+  sentenceSplitter: /[.!?]/
+} as const
+
 export function quickGuess(s: string): QuickGuessResult {
   const t = s.trim()
   if (!t) return 'ambiguous'
+
   if (t.includes('?')) return 'question'
+
   const lower = t.toLowerCase()
-  if (/(https?:\/\/|www\.)/.test(lower) || /\.[a-z]{2,}$/.test(lower)) return 'search'
-  if (/\b(site:|filetype:|intitle:|inurl:|OR|\-)\b/i.test(t)) return 'search'
-  if (
-    /^(how|why|what|who|when|where|which|can|could|should|do|does|did|is|are|am|was|were|explain|tell me|note|create)\b/i.test(
-      t
-    )
-  )
-    return 'question'
+
+  if (REGEX_PATTERNS.url.test(lower)) return 'search'
+
+  if (REGEX_PATTERNS.domain.test(lower)) return 'search'
+
+  if (REGEX_PATTERNS.searchOperators.test(t)) return 'search'
+
+  if (REGEX_PATTERNS.questionStarters.test(t)) return 'question'
+
+  // short queries (<=4 words) default to search
   const tokens = t.split(/\s+/)
-  if (tokens.length <= 4 && !/[!.?]/.test(t)) return 'search'
+  if (tokens.length <= 4) return 'search'
+
   return 'ambiguous'
 }
 
@@ -33,58 +48,38 @@ function fallbackClassify(text: string): ClassificationResult {
 
   if (guess === 'question') {
     return { intent: 'llm', confidence: 0.85 }
-  } else if (guess === 'search') {
-    return { intent: 'search', confidence: 0.85 }
-  } else {
-    // For ambiguous cases, use additional heuristics
-    const lower = text.toLowerCase()
-    const hasQuestionWords =
-      /\b(explain|describe|tell me|show me|help|tutorial|guide|learn)\b/.test(lower)
-    const hasComplexSentence = text.split(/[.!?]/).length > 1
-    const wordCount = text.trim().split(/\s+/).length
-
-    if (hasQuestionWords || hasComplexSentence || wordCount > 8) {
-      return { intent: 'llm', confidence: 0.65 }
-    } else {
-      return { intent: 'search', confidence: 0.65 }
-    }
   }
+
+  if (guess === 'search') {
+    return { intent: 'search', confidence: 0.85 }
+  }
+
+  const lower = text.toLowerCase()
+  const hasQuestionWords = REGEX_PATTERNS.questionWords.test(lower)
+  const hasComplexSentence = REGEX_PATTERNS.sentenceSplitter.test(text)
+  const wordCount = text.trim().split(/\s+/).length
+
+  if (hasQuestionWords || hasComplexSentence || wordCount > 8) {
+    return { intent: 'llm', confidence: 0.65 }
+  }
+
+  return { intent: 'search', confidence: 0.65 }
 }
 
 export async function classifyBatch(texts: string[]): Promise<BatchClassificationResult[]> {
-  const results = await Promise.all(
-    texts.map(async (text) => {
-      const result = await classifyIntent(text)
-      return {
-        intent: result.intent,
-        pLLM: result.intent === 'llm' ? result.confidence : 1 - result.confidence
-      }
-    })
-  )
-
-  return results
+  return texts.map((text) => {
+    const result = fallbackClassify(text)
+    return {
+      intent: result.intent,
+      pLLM: result.intent === 'llm' ? result.confidence : 1 - result.confidence
+    }
+  })
 }
 
 export async function decideIntent(s: string): Promise<ClassificationResultWithRoute> {
-  const fast = quickGuess(s)
+  const { intent, confidence } = fallbackClassify(s)
 
-  if (fast !== 'ambiguous') {
-    return {
-      intent: fast === 'question' ? 'llm' : 'search',
-      confidence: 0.95,
-      route: 'rules'
-    }
-  }
+  const route = confidence >= 0.8 ? 'rules' : 'fallback'
 
-  const { intent, confidence } = await classifyIntent(s)
-
-  if (confidence >= 0.6) {
-    return { intent, confidence, route: 'onnx' }
-  }
-
-  if (confidence <= 0.4) {
-    return { intent, confidence, route: 'onnx' }
-  }
-
-  return { intent, confidence, route: 'onnx-ambiguous' }
+  return { intent, confidence, route }
 }

--- a/packages/services/src/lib/ai/intentClassifier.types.ts
+++ b/packages/services/src/lib/ai/intentClassifier.types.ts
@@ -2,7 +2,7 @@ export type IntentType = 'search' | 'llm'
 
 export type QuickGuessResult = 'search' | 'question' | 'ambiguous'
 
-export type ClassificationRoute = 'rules' | 'onnx' | 'onnx-ambiguous'
+export type ClassificationRoute = 'rules' | 'onnx' | 'onnx-ambiguous' | 'fallback'
 
 export interface ClassificationResult {
   intent: IntentType

--- a/packages/services/src/lib/teletype/teletypeService.ts
+++ b/packages/services/src/lib/teletype/teletypeService.ts
@@ -443,7 +443,8 @@ export class TeletypeService {
         if (
           action.providerId === 'current-query' ||
           action.providerId === 'search' ||
-          action.providerId === 'hostname-search'
+          action.providerId === 'hostname-search' ||
+          action.providerId === 'navigation'
         ) {
           this.log.debug(`Always Search mode: Found Search action at index ${i}:`, action.name)
           return i
@@ -463,7 +464,8 @@ export class TeletypeService {
           intentResult.intent === 'search' &&
           (action.providerId === 'current-query' ||
             action.providerId === 'search' ||
-            action.providerId === 'hostname-search')
+            action.providerId === 'hostname-search' ||
+            action.providerId === 'navigation')
         ) {
           this.log.debug(`Auto mode: Found search-matching action at index ${i}:`, action.name)
           return i

--- a/packages/services/vitest.config.ts
+++ b/packages/services/vitest.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  test: {
+    globals: true,
+    environment: 'node',
+    include: ['src/**/*.{test,spec}.{js,ts}']
+  }
+})

--- a/yarn.lock
+++ b/yarn.lock
@@ -2158,6 +2158,14 @@
     "@types/node" "*"
     "@types/responselike" "^1.0.0"
 
+"@types/chai@^5.2.2":
+  version "5.2.3"
+  resolved "https://registry.yarnpkg.com/@types/chai/-/chai-5.2.3.tgz#8e9cd9e1c3581fa6b341a5aed5588eb285be0b4a"
+  integrity sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==
+  dependencies:
+    "@types/deep-eql" "*"
+    assertion-error "^2.0.1"
+
 "@types/cookie@^0.6.0":
   version "0.6.0"
   resolved "https://registry.npmjs.org/@types/cookie/-/cookie-0.6.0.tgz"
@@ -2169,6 +2177,11 @@
   integrity sha512-vIChWdVG3LG1SMxEvI/AK+FWJthlrqlTu7fbrlywTkkaONwk/UAGaULXRlf8vkzFBLVm0zkMdCquhL5aOjhXPQ==
   dependencies:
     "@types/ms" "*"
+
+"@types/deep-eql@*":
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/@types/deep-eql/-/deep-eql-4.0.2.tgz#334311971d3a07121e7eb91b684a605e7eea9cbd"
+  integrity sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==
 
 "@types/dom-view-transitions@^1.0.5":
   version "1.0.5"
@@ -2565,6 +2578,64 @@
     eslint-plugin-tsdoc "^0.2.17"
     eslint-plugin-unicorn "^48.0.1"
     prettier-plugin-packagejson "^2.4.5"
+
+"@vitest/expect@4.0.6":
+  version "4.0.6"
+  resolved "https://registry.yarnpkg.com/@vitest/expect/-/expect-4.0.6.tgz#33df10e2f9728b7338c2a2331c75814d1f840ab7"
+  integrity sha512-5j8UUlBVhOjhj4lR2Nt9sEV8b4WtbcYh8vnfhTNA2Kn5+smtevzjNq+xlBuVhnFGXiyPPNzGrOVvmyHWkS5QGg==
+  dependencies:
+    "@standard-schema/spec" "^1.0.0"
+    "@types/chai" "^5.2.2"
+    "@vitest/spy" "4.0.6"
+    "@vitest/utils" "4.0.6"
+    chai "^6.0.1"
+    tinyrainbow "^3.0.3"
+
+"@vitest/mocker@4.0.6":
+  version "4.0.6"
+  resolved "https://registry.yarnpkg.com/@vitest/mocker/-/mocker-4.0.6.tgz#3e27579d4444ca113685fc040961ce4b415ba5d2"
+  integrity sha512-3COEIew5HqdzBFEYN9+u0dT3i/NCwppLnO1HkjGfAP1Vs3vti1Hxm/MvcbC4DAn3Szo1M7M3otiAaT83jvqIjA==
+  dependencies:
+    "@vitest/spy" "4.0.6"
+    estree-walker "^3.0.3"
+    magic-string "^0.30.19"
+
+"@vitest/pretty-format@4.0.6":
+  version "4.0.6"
+  resolved "https://registry.yarnpkg.com/@vitest/pretty-format/-/pretty-format-4.0.6.tgz#af838540d3cd6b29c5d434fbdd36eb2543b040a3"
+  integrity sha512-4vptgNkLIA1W1Nn5X4x8rLJBzPiJwnPc+awKtfBE5hNMVsoAl/JCCPPzNrbf+L4NKgklsis5Yp2gYa+XAS442g==
+  dependencies:
+    tinyrainbow "^3.0.3"
+
+"@vitest/runner@4.0.6":
+  version "4.0.6"
+  resolved "https://registry.yarnpkg.com/@vitest/runner/-/runner-4.0.6.tgz#5a938015cfb202b96cbff4688400f1cd4899b40a"
+  integrity sha512-trPk5qpd7Jj+AiLZbV/e+KiiaGXZ8ECsRxtnPnCrJr9OW2mLB72Cb824IXgxVz/mVU3Aj4VebY+tDTPn++j1Og==
+  dependencies:
+    "@vitest/utils" "4.0.6"
+    pathe "^2.0.3"
+
+"@vitest/snapshot@4.0.6":
+  version "4.0.6"
+  resolved "https://registry.yarnpkg.com/@vitest/snapshot/-/snapshot-4.0.6.tgz#5cf47e396123cc379944632e908e74fb78d58f13"
+  integrity sha512-PaYLt7n2YzuvxhulDDu6c9EosiRuIE+FI2ECKs6yvHyhoga+2TBWI8dwBjs+IeuQaMtZTfioa9tj3uZb7nev1g==
+  dependencies:
+    "@vitest/pretty-format" "4.0.6"
+    magic-string "^0.30.19"
+    pathe "^2.0.3"
+
+"@vitest/spy@4.0.6":
+  version "4.0.6"
+  resolved "https://registry.yarnpkg.com/@vitest/spy/-/spy-4.0.6.tgz#3860eb53cfe333c5eefe8b510eb7d71da7f4bd70"
+  integrity sha512-g9jTUYPV1LtRPRCQfhbMintW7BTQz1n6WXYQYRQ25qkyffA4bjVXjkROokZnv7t07OqfaFKw1lPzqKGk1hmNuQ==
+
+"@vitest/utils@4.0.6":
+  version "4.0.6"
+  resolved "https://registry.yarnpkg.com/@vitest/utils/-/utils-4.0.6.tgz#e8ce743a4a5adcd7228823249b643bc894c0955d"
+  integrity sha512-bG43VS3iYKrMIZXBo+y8Pti0O7uNju3KvNn6DrQWhQQKcLavMB+0NZfO1/QBAEbq0MaQ3QjNsnnXlGQvsh0Z6A==
+  dependencies:
+    "@vitest/pretty-format" "4.0.6"
+    tinyrainbow "^3.0.3"
 
 "@volar/language-core@2.4.23", "@volar/language-core@~2.4.11":
   version "2.4.23"
@@ -2964,6 +3035,11 @@ assert@^2.0.0, assert@^2.1.0:
     object-is "^1.1.5"
     object.assign "^4.1.4"
     util "^0.12.5"
+
+assertion-error@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/assertion-error/-/assertion-error-2.0.1.tgz#f641a196b335690b1070bf00b6e7593fec190bf7"
+  integrity sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==
 
 ast-types-flow@^0.0.8:
   version "0.0.8"
@@ -3402,6 +3478,11 @@ ccount@^2.0.0:
   version "2.0.1"
   resolved "https://registry.npmjs.org/ccount/-/ccount-2.0.1.tgz"
   integrity sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==
+
+chai@^6.0.1:
+  version "6.2.0"
+  resolved "https://registry.yarnpkg.com/chai/-/chai-6.2.0.tgz#181bca6a219cddb99c3eeefb82483800ffa550ce"
+  integrity sha512-aUTnJc/JipRzJrNADXVvpVqi6CO0dn3nx4EVPxijri+fj3LUUDyZQOgVeW54Ob3Y1Xh9Iz8f+CgaCl8v0mn9bA==
 
 chainsaw@~0.1.0:
   version "0.1.0"
@@ -4019,9 +4100,9 @@ detect-node@^2.0.4:
   integrity sha512-T0NIuQpnTvFDATNuHN5roPwSBG83rFsuO+MXXH9/3N1eFbn4wcPjttvjMLEPWJ0RGUYgQE7cGgS3tNxbqCGM7g==
 
 devalue@^5.1.0, devalue@^5.3.2, devalue@^5.4.1:
-  version "5.4.1"
-  resolved "https://registry.yarnpkg.com/devalue/-/devalue-5.4.1.tgz#6086910772fa055d707f60a3e5858d26ef9dcf55"
-  integrity sha512-YtoaOfsqjbZQKGIMRYDWKjUmSB4VJ/RElB+bXZawQAQYAo4xu08GKTMVlsZDTF6R2MbAgjcAQRPI5eIyRAT2OQ==
+  version "5.4.2"
+  resolved "https://registry.yarnpkg.com/devalue/-/devalue-5.4.2.tgz#d002d836f9e92fc0c3bd9b76ea69129cbf99dca7"
+  integrity sha512-MwPZTKEPK2k8Qgfmqrd48ZKVvzSQjgW0lXLxiIBA8dQjtf/6mw6pggHNLcyDKyf+fI6eXxlQwPsfaCMTU5U+Bw==
 
 devlop@^1.0.0, devlop@^1.1.0:
   version "1.1.0"
@@ -4469,6 +4550,11 @@ es-iterator-helpers@^1.1.0:
     internal-slot "^1.0.7"
     iterator.prototype "^1.1.3"
     safe-array-concat "^1.1.2"
+
+es-module-lexer@^1.7.0:
+  version "1.7.0"
+  resolved "https://registry.yarnpkg.com/es-module-lexer/-/es-module-lexer-1.7.0.tgz#9159601561880a85f2734560a9099b2c31e5372a"
+  integrity sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==
 
 es-object-atoms@^1.0.0:
   version "1.0.0"
@@ -5004,6 +5090,11 @@ evp_bytestokey@^1.0.0, evp_bytestokey@^1.0.3:
   dependencies:
     md5.js "^1.3.4"
     safe-buffer "^5.1.1"
+
+expect-type@^1.2.2:
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/expect-type/-/expect-type-1.2.2.tgz#c030a329fb61184126c8447585bc75a7ec6fbff3"
+  integrity sha512-JhFGDVJ7tmDJItKhYgJCGLOWjuK9vPxiXoUFLwLDc99NlmklilbiQJwoctZtt13+xMw91MCk/REan6MWHqDjyA==
 
 expr-eval-fork@^2.0.2:
   version "2.0.2"
@@ -6837,6 +6928,13 @@ magic-string@^0.30.11, magic-string@^0.30.12, magic-string@^0.30.17, magic-strin
   integrity sha512-sNPKHvyjVf7gyjwS4xGTaW/mCnF8wnjtifKBEhxfZ7E/S8tQ0rssrwGNn6q8JH/ohItJfSQp9mBtQYuTlH5QnA==
   dependencies:
     "@jridgewell/sourcemap-codec" "^1.5.0"
+
+magic-string@^0.30.19:
+  version "0.30.21"
+  resolved "https://registry.yarnpkg.com/magic-string/-/magic-string-0.30.21.tgz#56763ec09a0fa8091df27879fd94d19078c00d91"
+  integrity sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==
+  dependencies:
+    "@jridgewell/sourcemap-codec" "^1.5.5"
 
 magic-string@^0.30.4:
   version "0.30.19"
@@ -9325,6 +9423,11 @@ side-channel@^1.1.0:
     side-channel-map "^1.0.1"
     side-channel-weakmap "^1.0.2"
 
+siginfo@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/siginfo/-/siginfo-2.0.0.tgz#32e76c70b79724e3bb567cb9d543eb858ccfaf30"
+  integrity sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==
+
 signal-exit@^4.0.1:
   version "4.1.0"
   resolved "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz"
@@ -9519,10 +9622,20 @@ sprintf-js@~1.0.2:
   resolved "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz"
   integrity sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==
 
+stackback@0.0.2:
+  version "0.0.2"
+  resolved "https://registry.yarnpkg.com/stackback/-/stackback-0.0.2.tgz#1ac8a0d9483848d1695e418b6d031a3c3ce68e3b"
+  integrity sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==
+
 stat-mode@^1.0.0:
   version "1.0.0"
   resolved "https://registry.npmjs.org/stat-mode/-/stat-mode-1.0.0.tgz"
   integrity sha512-jH9EhtKIjuXZ2cWxmXS8ZP80XyC3iasQxMDV8jzhNJpfDb7VbQLVW4Wvsxz9QZvzV+G4YoSfBUVKDOyxLzi/sg==
+
+std-env@^3.9.0:
+  version "3.10.0"
+  resolved "https://registry.yarnpkg.com/std-env/-/std-env-3.10.0.tgz#d810b27e3a073047b2b5e40034881f5ea6f9c83b"
+  integrity sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==
 
 stream-browserify@^3.0.0:
   version "3.0.0"
@@ -10104,10 +10217,20 @@ tiny-typed-emitter@^2.1.0:
   resolved "https://registry.npmjs.org/tiny-typed-emitter/-/tiny-typed-emitter-2.1.0.tgz"
   integrity sha512-qVtvMxeXbVej0cQWKqVSSAHmKZEHAvxdF8HEUBFWts8h+xEo5m/lEiPakuyZ3BnCBjOD8i24kzNOiOLLgsSxhA==
 
+tinybench@^2.9.0:
+  version "2.9.0"
+  resolved "https://registry.yarnpkg.com/tinybench/-/tinybench-2.9.0.tgz#103c9f8ba6d7237a47ab6dd1dcff77251863426b"
+  integrity sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==
+
 tinycolor2@^1.6.0:
   version "1.6.0"
   resolved "https://registry.yarnpkg.com/tinycolor2/-/tinycolor2-1.6.0.tgz#f98007460169b0263b97072c5ae92484ce02d09e"
   integrity sha512-XPaBkWQJdsf3pLKJV9p4qN/S+fm2Oj8AIPo1BTUhg5oxkvm9+SVEGFdhyOz7tTdUTfvxMiAs4sp6/eZO2Ew+pw==
+
+tinyexec@^0.3.2:
+  version "0.3.2"
+  resolved "https://registry.yarnpkg.com/tinyexec/-/tinyexec-0.3.2.tgz#941794e657a85e496577995c6eef66f53f42b3d2"
+  integrity sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==
 
 tinyglobby@^0.2.10, tinyglobby@^0.2.15:
   version "0.2.15"
@@ -10116,6 +10239,11 @@ tinyglobby@^0.2.10, tinyglobby@^0.2.15:
   dependencies:
     fdir "^6.5.0"
     picomatch "^4.0.3"
+
+tinyrainbow@^3.0.3:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/tinyrainbow/-/tinyrainbow-3.0.3.tgz#984a5b1c1b25854a9b6bccbe77964d0593d1ea42"
+  integrity sha512-PSkbLUoxOFRzJYjjxHJt9xro7D+iilgMX/C9lawzVuYiIdcihh9DXmVibBe8lmcFrRi/VzlPjBxbN7rH24q8/Q==
 
 tippy.js@^6.3.7:
   version "6.3.7"
@@ -10706,6 +10834,20 @@ vite-plugin-node-polyfills@^0.24.0:
     "@rollup/plugin-inject" "^5.0.5"
     node-stdlib-browser "^1.2.0"
 
+"vite@^6.0.0 || ^7.0.0":
+  version "7.1.12"
+  resolved "https://registry.yarnpkg.com/vite/-/vite-7.1.12.tgz#8b29a3f61eba23bcb93fc9ec9af4a3a1e83eecdb"
+  integrity sha512-ZWyE8YXEXqJrrSLvYgrRP7p62OziLW7xI5HYGWFzOvupfAlrLvURSzv/FyGyy0eidogEM3ujU+kUG1zuHgb6Ug==
+  dependencies:
+    esbuild "^0.25.0"
+    fdir "^6.5.0"
+    picomatch "^4.0.3"
+    postcss "^8.5.6"
+    rollup "^4.43.0"
+    tinyglobby "^0.2.15"
+  optionalDependencies:
+    fsevents "~2.3.3"
+
 vite@^7.1.11, vite@^7.1.5:
   version "7.1.11"
   resolved "https://registry.yarnpkg.com/vite/-/vite-7.1.11.tgz#4d006746112fee056df64985191e846ebfb6007e"
@@ -10729,6 +10871,32 @@ vitefu@^1.1.1:
   version "1.1.1"
   resolved "https://registry.npmjs.org/vitefu/-/vitefu-1.1.1.tgz"
   integrity sha512-B/Fegf3i8zh0yFbpzZ21amWzHmuNlLlmJT6n7bu5e+pCHUKQIfXSYokrqOBGEMMe9UG2sostKQF9mml/vYaWJQ==
+
+vitest@^4.0.6:
+  version "4.0.6"
+  resolved "https://registry.yarnpkg.com/vitest/-/vitest-4.0.6.tgz#a0cbc78192cce8726d06c471b8e5b5b9cc6beea5"
+  integrity sha512-gR7INfiVRwnEOkCk47faros/9McCZMp5LM+OMNWGLaDBSvJxIzwjgNFufkuePBNaesGRnLmNfW+ddbUJRZn0nQ==
+  dependencies:
+    "@vitest/expect" "4.0.6"
+    "@vitest/mocker" "4.0.6"
+    "@vitest/pretty-format" "4.0.6"
+    "@vitest/runner" "4.0.6"
+    "@vitest/snapshot" "4.0.6"
+    "@vitest/spy" "4.0.6"
+    "@vitest/utils" "4.0.6"
+    debug "^4.4.3"
+    es-module-lexer "^1.7.0"
+    expect-type "^1.2.2"
+    magic-string "^0.30.19"
+    pathe "^2.0.3"
+    picomatch "^4.0.3"
+    std-env "^3.9.0"
+    tinybench "^2.9.0"
+    tinyexec "^0.3.2"
+    tinyglobby "^0.2.15"
+    tinyrainbow "^3.0.3"
+    vite "^6.0.0 || ^7.0.0"
+    why-is-node-running "^2.3.0"
 
 vm-browserify@^1.0.1:
   version "1.1.2"
@@ -10837,6 +11005,14 @@ which@^2.0.1:
   integrity sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==
   dependencies:
     isexe "^2.0.0"
+
+why-is-node-running@^2.3.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/why-is-node-running/-/why-is-node-running-2.3.0.tgz#a3f69a97107f494b3cdc3bdddd883a7d65cebf04"
+  integrity sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==
+  dependencies:
+    siginfo "^2.0.0"
+    stackback "0.0.2"
 
 word-wrap@^1.2.5:
   version "1.2.5"


### PR DESCRIPTION
### Changes


- Fixed cases with queries ending with periods (partial domains) and slashes were wrongly classified as LLM queries, also causing active teletype selection index to be set to the wrong selection (github.com/deta/surf would be selected as github.com only)

- Also simplified and optimized the intent classification with compiled regexes and removal of dup function calls

- Added simple sanity intent classifier tests
