### PR TITLE
chore (deps-dev): bump electron to 39.1.0

### DIFF
--- a/.github/workflows/build_on_pr_label.yml
+++ b/.github/workflows/build_on_pr_label.yml
@@ -51,7 +51,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 22.20.0
+          node-version: 22.21.1
 
       - name: Set up Rust
         uses: actions-rs/toolchain@v1

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -36,7 +36,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v4
         with:
-          node-version: 22.20.0
+          node-version: 22.21.1
 
       - run: npm install semver
 
@@ -89,7 +89,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 22.20.0
+          node-version: 22.21.1
 
       - name: Set up Rust
         uses: actions-rs/toolchain@v1

--- a/.github/workflows/pull_request_frontend.yml
+++ b/.github/workflows/pull_request_frontend.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 22.20.0
+          node-version: 22.21.1
 
       - name: Cache node_modules
         uses: actions/cache@v3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -79,7 +79,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 22.20.0
+          node-version: 22.21.1
 
       - name: Set up Rust
         uses: actions-rs/toolchain@v1

--- a/app/package.json
+++ b/app/package.json
@@ -62,7 +62,7 @@
     "autoprefixer": "^10.4.19",
     "bits-ui": "^2.9.3",
     "debug": "^4.4.3",
-    "electron": "39.0.0",
+    "electron": "39.1.0",
     "electron-builder": "^24.13.3",
     "electron-context-menu": "^3.6.1",
     "electron-vite": "^4.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4372,10 +4372,10 @@ electron-vite@^4.0.0:
     magic-string "^0.30.17"
     picocolors "^1.1.1"
 
-electron@39.0.0:
-  version "39.0.0"
-  resolved "https://registry.yarnpkg.com/electron/-/electron-39.0.0.tgz#6906720c5bd3c40f98f6e01802fdc301654c4550"
-  integrity sha512-UejnuOK4jpRZUq7MkEAnR/szsRWLKBJAdvn6j3xdQLT57fVv13VSNdaUHHjSheaqGzNhCGIdkPsPJnGJVh5kiA==
+electron@39.1.0:
+  version "39.1.0"
+  resolved "https://registry.yarnpkg.com/electron/-/electron-39.1.0.tgz#58768272db3b1b0475bf558950f5b394edde802c"
+  integrity sha512-vPRbKKQUzKWZZX68fuYdz4iS/eavGcQkHOGK4ylv0YJLbBRxxUlflPRdqRGflFjwid+sja7gbNul2lArevYwrw==
   dependencies:
     "@electron/get" "^2.0.0"
     "@types/node" "^22.7.7"


### PR DESCRIPTION
## Changes

- Bump electron to [39.1.0](https://releases.electronjs.org/release/v39.1.0) 
- Bump Node to 22.21.1 in github workflows