### PR TITLE
fix: fix ask Surf in drafts notebook

### DIFF
--- a/packages/services/src/lib/browser/browser.svelte.ts
+++ b/packages/services/src/lib/browser/browser.svelte.ts
@@ -288,7 +288,9 @@ export class BrowserService {
       let notebookId: string | null = null
 
       const { type, id } = view.typeDataValue
-      if (type === ViewType.Notebook && id) {
+
+      // 'drafts' is special and should be treated as no notebook
+      if (type === ViewType.Notebook && id && id !== 'drafts') {
         notebookId = id
       }
 


### PR DESCRIPTION
### Changes

- Treat `drafts` as no notebook and keep notebookId null in teletype ask handler in browser serivce, fixes the issue where you can't ask a question in `Drafts` notebook