### PR TITLE
chore (workflows): update macos x64 runner to macos-15-intel in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -54,7 +54,7 @@ jobs:
             matrix="$matrix{\"os\":\"macos-14\",\"architecture\":\"arm\",\"build_command\":\"yarn build:desktop:mac:arm\"},"
           fi
           if [[ "${{ inputs.run_macos_x64 }}" == "true" ]]; then
-            matrix="$matrix{\"os\":\"macos-13\",\"architecture\":\"x64\",\"build_command\":\"yarn build:desktop:mac:x64\"},"
+            matrix="$matrix{\"os\":\"macos-15-intel\",\"architecture\":\"x64\",\"build_command\":\"yarn build:desktop:mac:x64\"},"
           fi
           if [[ "${{ inputs.run_windows_x64 }}" == "true" ]]; then
             matrix="$matrix{\"os\":\"windows-latest\",\"architecture\":\"x64\",\"build_command\":\"yarn build:desktop:win:x64\"},"


### PR DESCRIPTION
## Changes

- Update macos x64 runner to `macos-15-intel` in macos runner