### PR TITLE
chore (deps-dev): bump expr-eval-fork to ^3.0.0 through resolutions

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "cookie": "^0.7.0",
     "brace-expansion": "^2.0.2",
     "tmp": "^0.2.4",
-    "devalue": "^5.4.1"
+    "devalue": "^5.4.1",
+    "expr-eval-fork": "^3.0.0"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -5096,10 +5096,10 @@ expect-type@^1.2.2:
   resolved "https://registry.yarnpkg.com/expect-type/-/expect-type-1.2.2.tgz#c030a329fb61184126c8447585bc75a7ec6fbff3"
   integrity sha512-JhFGDVJ7tmDJItKhYgJCGLOWjuK9vPxiXoUFLwLDc99NlmklilbiQJwoctZtt13+xMw91MCk/REan6MWHqDjyA==
 
-expr-eval-fork@^2.0.2:
-  version "2.0.2"
-  resolved "https://registry.yarnpkg.com/expr-eval-fork/-/expr-eval-fork-2.0.2.tgz#97136ac0a8178522055500f55d3d3c5ad54f400d"
-  integrity sha512-NaAnObPVwHEYrODd7Jzp3zzT9pgTAlUUL4MZiZu9XAYPDpx89cPsfyEImFb2XY0vQNbrqg2CG7CLiI+Rs3seaQ==
+expr-eval-fork@^2.0.2, expr-eval-fork@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/expr-eval-fork/-/expr-eval-fork-3.0.0.tgz#5c8327acc399405b168fccfe917f161c076b2840"
+  integrity sha512-29S+IZ2g8qSk5q7gOUYozO7zi4mj/sCVo+HB2h0f0ER4ZCZr9b/+5SWIedvV0SHq3IxBW2/TJrPn77YxMsoVwg==
 
 exsolve@^1.0.7:
   version "1.0.7"


### PR DESCRIPTION
### Changes

- Bumps `expr-eval-fork` (dev dependency) to `^3.0.0` through resolutions to address [CVE](https://github.com/advisories/GHSA-jc85-fpwf-qm7x)
