### PR TITLE
chore (deps): bump js-yaml to 3.14.2, 4.1.1 through resolutions

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,6 +55,9 @@
     "brace-expansion": "^2.0.2",
     "tmp": "^0.2.4",
     "devalue": "^5.4.1",
-    "expr-eval-fork": "^3.0.0"
+    "expr-eval-fork": "^3.0.0",
+    "gray-matter/js-yaml": "3.14.2",
+    "front-matter/js-yaml": "3.14.2",
+    "electron-builder/**/js-yaml": "4.1.1"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -6590,18 +6590,18 @@ js-base64@^3.7.5:
   resolved "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz"
   integrity sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==
 
-js-yaml@^3.13.1:
-  version "3.14.1"
-  resolved "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz"
-  integrity sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==
+js-yaml@3.14.2, js-yaml@^3.13.1:
+  version "3.14.2"
+  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.14.2.tgz#77485ce1dd7f33c061fd1b16ecea23b55fcb04b0"
+  integrity sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==
   dependencies:
     argparse "^1.0.7"
     esprima "^4.0.0"
 
-js-yaml@^4.1.0:
-  version "4.1.0"
-  resolved "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz"
-  integrity sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==
+js-yaml@4.1.1, js-yaml@^4.1.0:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-4.1.1.tgz#854c292467705b699476e1a2decc0c8a3458806b"
+  integrity sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==
   dependencies:
     argparse "^2.0.1"
 


### PR DESCRIPTION
### Changes

- Bump `js-yaml` to 3.14.2, 4.1.1 to address [CVE](https://github.com/advisories/GHSA-mh29-5h37-fv8m).

Currently the CVE database shows only `4.1.1` as patched but the [fix was backported to `3.14.2` as well](https://github.com/github/advisory-database/pull/6420).
