### PR TITLE
fix: fix wrong api call usage of list resources by tags APIs

### DIFF
--- a/packages/services/src/lib/browser/browser.svelte.ts
+++ b/packages/services/src/lib/browser/browser.svelte.ts
@@ -416,18 +416,21 @@ export class BrowserService {
     try {
       this.log.debug('Preparing new note view')
 
-      const existingResources = await this.resourceManager.listResourcesByTags([
-        SearchResourceTags.Deleted(false),
-        SearchResourceTags.ResourceType(ResourceTypes.DOCUMENT_SPACE_NOTE),
-        SearchResourceTags.PreloadedResource(true)
-      ])
+      const existingResources = await this.resourceManager.listResourcesByTags(
+        [
+          SearchResourceTags.Deleted(false),
+          SearchResourceTags.ResourceType(ResourceTypes.DOCUMENT_SPACE_NOTE),
+          SearchResourceTags.PreloadedResource(true)
+        ],
+        { limit: 1 }
+      )
 
       this.log.debug('Found existing preloaded resources:', existingResources)
 
       let resource: ResourceNote | null = null
 
-      if (existingResources.length > 0) {
-        resource = existingResources[0] as ResourceNote
+      if (existingResources?.items.length > 0) {
+        resource = existingResources.items[0] as ResourceNote
       } else {
         resource = await this.resourceManager.createResourceNote(
           '',

--- a/packages/services/src/lib/notebooks/notebookManager.svelte.ts
+++ b/packages/services/src/lib/notebooks/notebookManager.svelte.ts
@@ -1,8 +1,7 @@
 import { onMount, tick } from 'svelte'
-import { derived, get, writable, type Readable, type Writable } from 'svelte/store'
+import { get, writable, type Writable } from 'svelte/store'
 
 import {
-  conditionalArrayItem,
   isDev,
   useLogScope,
   EventEmitterBase,
@@ -769,19 +768,16 @@ export class NotebookManager extends EventEmitterBase<NotebookManagerEventHandle
       await tick()
 
       const excludeAnnotations = !get(this.config.settings).show_annotations_in_oasis
-      // const selectedFilterType = get(this.selectedFilterType)
 
       this.log.debug('loading everything', { excludeAnnotations })
-      const resources = await this.resourceManager.listResourcesByTags(
+      const resources = await this.resourceManager.listAllResourcesByTags(
         [
           ...SearchResourceTags.NonHiddenDefaultTags({
             excludeAnnotations: excludeAnnotations
           })
-          // ...conditionalArrayItem(selectedFilterType !== null, selectedFilterType?.tags ?? []),
         ],
         {
           includeAnnotations: true
-          //excludeWithinSpaces: get(this.selectedNotebook) === 'inbox'
         }
       )
 

--- a/packages/services/src/lib/resources/resources.svelte.ts
+++ b/packages/services/src/lib/resources/resources.svelte.ts
@@ -996,7 +996,7 @@ export class ResourceManager extends EventEmitterBase<ResourceManagerEventHandle
     const result = await this.sffs.listResourceIDsByTags(tags, paginationParams, opts?.spaceId)
     // TODO: is this the right behavior?
     if (!result) {
-      return []
+      throw new Error('failed to list resources by tags')
     }
     this.log.debug('found resource ids', result.items)
     const resources = (await Promise.all(


### PR DESCRIPTION
## Changes

- Fixes wrong API calls for `resourceMangager.listResourcesByTags` after pagination update
