### PR TITLE
chore (deps-dev): bump electron to 39.2.4

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -62,7 +62,7 @@
     "autoprefixer": "^10.4.19",
     "bits-ui": "^2.9.3",
     "debug": "^4.4.3",
-    "electron": "39.2.3",
+    "electron": "39.2.4",
     "electron-builder": "^24.13.3",
     "electron-context-menu": "^3.6.1",
     "electron-vite": "^4.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4372,10 +4372,10 @@ electron-vite@^4.0.0:
     magic-string "^0.30.17"
     picocolors "^1.1.1"
 
-electron@39.2.3:
-  version "39.2.3"
-  resolved "https://registry.yarnpkg.com/electron/-/electron-39.2.3.tgz#33d5b74f6cf91c6c4444424fb068c4d6f8541e6b"
-  integrity sha512-j7k7/bj3cNA29ty54FzEMRUoqirE+RBQPhPFP+XDuM93a1l2WcDPiYumxKWz+iKcXxBJLFdMIAlvtLTB/RfCkg==
+electron@39.2.4:
+  version "39.2.4"
+  resolved "https://registry.yarnpkg.com/electron/-/electron-39.2.4.tgz#5ba17fd8fbfc5e6e50e6855f31b433a558030bea"
+  integrity sha512-KxPtwpFceQKSxRtUY39piHLYhJMMyHfOhc70e6zRnKGrbRdK6hzEqssth8IGjlKOdkeT4KCvIEngnNraYk39+g==
   dependencies:
     "@electron/get" "^2.0.0"
     "@types/node" "^22.7.7"


### PR DESCRIPTION
## Changes

- Bump electron to [39.2.4](https://releases.electronjs.org/release/v39.2.4)