### PR TITLE
feat: add LiteLLM as custom model provider

### DIFF
--- a/packages/icons/src/lib/Icons/LiteLLM.svelte
+++ b/packages/icons/src/lib/Icons/LiteLLM.svelte
@@ -1,0 +1,3 @@
+<svg viewBox="0 0 24 24" fill="currentColor" xmlns="http://www.w3.org/2000/svg" {...$$restProps}>
+  <text x="12" y="18" font-size="20" text-anchor="middle">🚅</text>
+</svg>

--- a/packages/icons/src/lib/main.ts
+++ b/packages/icons/src/lib/main.ts
@@ -151,6 +151,7 @@ import LinkExternal from './Icons/LinkExternal.svelte'
 import Ollama from './Icons/Ollama.svelte'
 import OpenRouter from './Icons/OpenRouter.svelte'
 import HuggingFace from './Icons/HuggingFace.svelte'
+import LiteLLM from './Icons/LiteLLM.svelte'
 
 import DynamicIcon from './DynamicIcon.svelte'
 
@@ -309,7 +310,8 @@ export const icons = {
   book: Book,
   ollama: Ollama,
   openrouter: OpenRouter,
-  huggingface: HuggingFace
+  huggingface: HuggingFace,
+  litellm: LiteLLM
 }
 
 export type Icons = keyof typeof icons
@@ -470,5 +472,6 @@ export {
   LinkExternal,
   Ollama,
   OpenRouter,
-  HuggingFace
+  HuggingFace,
+  LiteLLM
 }

--- a/packages/types/src/ai.types.ts
+++ b/packages/types/src/ai.types.ts
@@ -362,7 +362,8 @@ export enum CUSTOM_MODELS {
   Ollama = 'Ollama',
   OpenRouter = 'OpenRouter',
   HuggingFaceTogether = 'Hugging Face Together AI',
-  HuggingFace = 'Hugging Face Inference Endpoint'
+  HuggingFace = 'Hugging Face Inference Endpoint',
+  LiteLLM = 'LiteLLM'
 }
 
 export type CustomModelType = keyof typeof CUSTOM_MODELS
@@ -408,6 +409,14 @@ export const CUSTOM_MODEL_DEFINITIONS: Record<CUSTOM_MODELS, CustomModelDefiniti
     provider_url: 'https://api-inference.huggingface.co/models/',
     model_page: 'https://huggingface.co/models?inference_provider=together&sort=trending',
     api_key_page: 'https://huggingface.co/settings/tokens'
+  },
+  [CUSTOM_MODELS.LiteLLM]: {
+    id: CUSTOM_MODELS.LiteLLM,
+    label: 'LiteLLM',
+    icon: 'litellm',
+    provider_url: 'http://localhost:4000/v1/chat/completions',
+    model_page: 'https://docs.litellm.ai/docs/providers',
+    api_key_page: 'https://docs.litellm.ai/docs/simple_proxy#quick-start'
   }
 }
 


### PR DESCRIPTION


## Summary
- Adds [LiteLLM](https://github.com/BerriAI/litellm) as a custom model provider, enabling users to route AI requests through 100+ LLM providers (OpenAI, Anthropic, Azure, Bedrock, Vertex AI, Groq, Ollama, etc.) via a single LiteLLM proxy.
- Follows the existing custom model pattern (same structure as Ollama, OpenRouter, HuggingFace).

## Motivation
LiteLLM acts as a unified AI gateway. Instead of configuring individual provider API keys, users can point Surf at a single LiteLLM proxy that handles provider routing, load balancing, and cost tracking across 100+ providers. Useful for users who need providers not yet directly supported (e.g., AWS Bedrock, Vertex AI, Mistral, Cohere), or teams running a centralized LLM proxy.

## Changes

- `packages/types/src/ai.types.ts` - added `LiteLLM = 'LiteLLM'` to `CUSTOM_MODELS` enum, added LiteLLM entry to `CUSTOM_MODEL_DEFINITIONS` with default proxy URL, model docs link, and API key docs link
- `packages/icons/src/lib/Icons/LiteLLM.svelte` - new icon component (bullet train, matching LiteLLM's brand)
- `packages/icons/src/lib/main.ts` - registered LiteLLM icon in the icon map and exports

## Tests

**Live E2E - basic completion via LiteLLM proxy routing to Claude Sonnet 4.6:**

    === Test 1: Basic completion ===
    Status: 200
    Model: claude-sonnet-4-6
    Content: OK
    Finish: stop

**Live E2E - streaming via LiteLLM proxy:**

    === Test 2: Streaming ===
    Streamed: Hello!

SSE chunks parsed correctly through the same `/v1/chat/completions` endpoint Surf uses for Ollama and OpenRouter custom models.

**Error handling - invalid model:**

    === Test 3: Invalid model ===
    Status: 200
    Error handled: YES

All 3 tests use raw `fetch("http://localhost:4000/v1/chat/completions")` matching the exact call path Surf uses for custom models via `OPEN_AI_PATH_SUFFIX`.

## Risk / Compatibility
- Additive only. No existing models or providers modified.
- No new dependencies - LiteLLM proxy is OpenAI-compatible, uses the same request/response format as Ollama and OpenRouter.
- 3 files changed, 18 lines added.

## Example usage

**1. Start a LiteLLM proxy:**

    pip install litellm
    litellm --model anthropic/claude-3-5-sonnet --port 4000

**2. In Surf Settings > AI > Custom Model, select "LiteLLM"**

**3. Enter model name** using LiteLLM's `provider/model` format:

    openai/gpt-4o-mini           # OpenAI via LiteLLM
    anthropic/claude-3-5-sonnet  # Anthropic via LiteLLM
    azure/gpt-4                  # Azure via LiteLLM
    bedrock/anthropic.claude-3   # AWS Bedrock via LiteLLM
    vertex_ai/gemini-pro         # Vertex AI via LiteLLM
    groq/llama-3.3-70b           # Groq via LiteLLM

**4. Edit the proxy URL** 

    https://my-proxy.example.com/v1/chat/completions   # remote proxy

**5. Enter your LiteLLM proxy API key** (if required)
