### PR TITLE
fix: ignore Enter during IME composition in command palette

### DIFF
--- a/packages/teletype/src/components/Teletype/TeletypeCore.svelte
+++ b/packages/teletype/src/components/Teletype/TeletypeCore.svelte
@@ -207,7 +207,7 @@
       callAction(action)
     }
 
-    if (e.key === 'Enter' && !e.shiftKey) {
+    if (e.key === 'Enter' && !e.shiftKey && !e.isComposing) {
       if ($currentAction?.requireInput) {
         e.preventDefault()
         callAction($currentAction)


### PR DESCRIPTION
With a Japanese, Chinese or Korean IME, the first Enter confirms the active composition candidate instead of submitting. In `TeletypeCore`, `handleInputKey` ran `callAction` on `e.key === 'Enter' && !e.shiftKey`, so confirming a candidate fired the action (or the fallback action) on a half-typed query.

I added `!e.isComposing` to that condition, so Enter only acts once composition has ended. A normal Enter is unaffected.

Repro: set the OS to a Japanese IME, open the command palette, type a query such as `けんさく` and press Enter to pick a candidate.
- Before: the action runs on the unfinished text.
- After: that Enter confirms the candidate, and a second Enter runs the action.
